### PR TITLE
Add bFirstPersonOverhaulEnableArmsOnSprint Option.

### DIFF
--- a/ImprovedCamera/include/settings/Settings.h
+++ b/ImprovedCamera/include/settings/Settings.h
@@ -62,10 +62,11 @@ namespace Settings {
 		bool bAttackBow;
 		bool bKillmove;
 	};
-	// 7 Settings
+	// 8 Settings
 	struct Fixes {
 		bool bQuickLightLighting;
 		bool bFirstPersonOverhaul;
+		bool bFirstPersonOverhaulEnableArmsOnSprint; // Temporary Location for Config Option. Move to new UI TAB for First Person Overhaul Fixes?
 		bool bArcheryGameplayOverhaul;
 		float fSwitchPOVDetectDistance;
 		bool bSmoothAnimationTransitions;

--- a/ImprovedCamera/source/menu/Fixes.cpp
+++ b/ImprovedCamera/source/menu/Fixes.cpp
@@ -26,6 +26,14 @@ namespace Menu {
 		{
 			ImGui::TableItemToggleButton("QuickLight Lighting", "##QuickLightLighting", &m_pluginConfig->m_Fixes.bQuickLightLighting);
 			ImGui::TableItemToggleButton("First Person Overhaul", "##FirstPersonOverhaul", &m_pluginConfig->m_Fixes.bFirstPersonOverhaul);
+			if (!m_pluginConfig->m_Fixes.bFirstPersonOverhaul)
+				ImGui::BeginDisabled();
+
+			ImGui::TableItemToggleButton("First Person Overhaul: Enable Arms on Sprint", "##FirstPersonOverhaulEnableArmsOnSprint", &m_pluginConfig->m_Fixes.bFirstPersonOverhaulEnableArmsOnSprint);
+
+			if (!m_pluginConfig->m_Fixes.bFirstPersonOverhaul)
+				ImGui::EndDisabled();
+
 			ImGui::TableItemToggleButton("Archery Gameplay Overhaul", "##ArcheryGameplayOverhaul", &m_pluginConfig->m_Fixes.bArcheryGameplayOverhaul);
 			ImGui::TableItemSliderFloat("Switch POV Detect Distance", "##SwitchPOVDetectDistance", &m_pluginConfig->m_Fixes.fSwitchPOVDetectDistance, 0.01f, 0.20f, "%.2f");
 			ImGui::NewLine();

--- a/ImprovedCamera/source/skyrimse/ImprovedCameraSE.cpp
+++ b/ImprovedCamera/source/skyrimse/ImprovedCameraSE.cpp
@@ -889,7 +889,7 @@ namespace ImprovedCamera {
 			return false;
 
 		if (m_CurrentCameraID == RE::CameraState::kFirstPerson && (playerState->IsSprinting() || player->IsInMidair() || playerState->IsSwimming()) && !m_Paragliding &&
-			!playerState->IsWeaponDrawn() && !Helper::IsBeastMode() && !m_pluginConfig->General().bEnableThirdPersonArms && m_pluginConfig->Fixes().bFirstPersonOverhaul)
+			!playerState->IsWeaponDrawn() && !Helper::IsBeastMode() && !m_pluginConfig->General().bEnableThirdPersonArms && m_pluginConfig->Fixes().bFirstPersonOverhaul && !m_pluginConfig->Fixes().bFirstPersonOverhaulEnableArmsOnSprint)
 		{
 			return false;
 		}
@@ -926,7 +926,7 @@ namespace ImprovedCamera {
 		bool torchEquipped = Helper::IsTorchEquipped(player);
 
 		// CFPAO/First Person Left Arm fix
-		if (((playerState->IsSprinting() || player->IsInMidair()) && !playerState->IsWeaponDrawn() && !Helper::IsBeastMode() && m_pluginConfig->Fixes().bFirstPersonOverhaul) ||
+		if (((playerState->IsSprinting() || player->IsInMidair()) && !playerState->IsWeaponDrawn() && !Helper::IsBeastMode() && m_pluginConfig->Fixes().bFirstPersonOverhaul && !m_pluginConfig->Fixes().bFirstPersonOverhaulEnableArmsOnSprint) ||
 			m_FirstPersonLeftArm)
 		{
 			return false;
@@ -963,7 +963,7 @@ namespace ImprovedCamera {
 		auto playerState = player->AsActorState();
 
 		// CFPAO/First Person Right Arm fix
-		if (((playerState->IsSprinting() || player->IsInMidair()) && !playerState->IsWeaponDrawn() && !Helper::IsBeastMode() && m_pluginConfig->Fixes().bFirstPersonOverhaul) ||
+		if (((playerState->IsSprinting() || player->IsInMidair()) && !playerState->IsWeaponDrawn() && !Helper::IsBeastMode() && m_pluginConfig->Fixes().bFirstPersonOverhaul && !m_pluginConfig->Fixes().bFirstPersonOverhaulEnableArmsOnSprint) ||
 			m_FirstPersonRightArm)
 		{
 			return false;

--- a/ImprovedCamera/source/systems/Config.cpp
+++ b/ImprovedCamera/source/systems/Config.cpp
@@ -103,6 +103,7 @@ namespace Systems {
 
 				m_Fixes.bQuickLightLighting = std::stoi(ini.get("FIXES").get("bQuickLightLighting"));
 				m_Fixes.bFirstPersonOverhaul = std::stoi(ini.get("FIXES").get("bFirstPersonOverhaul"));
+				m_Fixes.bFirstPersonOverhaulEnableArmsOnSprint = std::stoi(ini.get("FIXES").get("bFirstPersonOverhaulEnableArmsOnSprint"));
 				m_Fixes.bArcheryGameplayOverhaul = std::stoi(ini.get("FIXES").get("bArcheryGameplayOverhaul"));
 				m_Fixes.fSwitchPOVDetectDistance = std::stof(ini.get("FIXES").get("fSwitchPOVDetectDistance"));
 				m_Fixes.bSmoothAnimationTransitions = std::stoi(ini.get("FIXES").get("bSmoothAnimationTransitions"));
@@ -321,6 +322,7 @@ namespace Systems {
 
 			ini["FIXES"]["bQuickLightLighting"] = std::to_string(m_Fixes.bQuickLightLighting);
 			ini["FIXES"]["bFirstPersonOverhaul"] = std::to_string(m_Fixes.bFirstPersonOverhaul);
+			ini["FIXES"]["bFirstPersonOverhaulEnableArmsOnSprint"] = std::to_string(m_Fixes.bFirstPersonOverhaulEnableArmsOnSprint);
 			ini["FIXES"]["bArcheryGameplayOverhaul"] = std::to_string(m_Fixes.bArcheryGameplayOverhaul);
 			ini["FIXES"]["fSwitchPOVDetectDistance"] = std::to_string(m_Fixes.fSwitchPOVDetectDistance);
 			ini["FIXES"]["bSmoothAnimationTransitions"] = std::to_string(m_Fixes.bSmoothAnimationTransitions);

--- a/assets/ImprovedCamera/assets/Profiles/Default.ini
+++ b/assets/ImprovedCamera/assets/Profiles/Default.ini
@@ -60,6 +60,9 @@ bQuickLightLighting=1
 ; Fixes First Person Overhaul mods.
 bFirstPersonOverhaul=0
 
+; Disables Arms being hidden when sprinting with bFirstPersonOverhaul=1 (For when you did not install CFPAO's Sprint Animations)
+bFirstPersonOverhaulEnableArmsOnSprint=0
+
 ; Fixes Archery Gameplay Overhaul drawn animation.
 bArcheryGameplayOverhaul=0
 

--- a/assets/ImprovedCamera/assets/editorconfig.ini
+++ b/assets/ImprovedCamera/assets/editorconfig.ini
@@ -30,7 +30,7 @@ Collapsed=0
 
 [Window][[FIXES]]
 Pos=10,40
-Size=335,304
+Size=590,304
 Collapsed=0
 
 [Window][[RESTRICT ANGLES]]


### PR DESCRIPTION
Added option to enable arms to be visible in First Person when sprinting. With the bFirstPersonOverhaul FIX enabled. (For when not using CFPAO's Sprint Animations)

If you need to contact me. I'm on Discord as kruziikrel13. (Also in the Improved Camera Discord)