### PR TITLE
Fix: Loading Time with Custom Window Mod

### DIFF
--- a/ImprovedCamera/source/skyrimse/SkyrimSE.cpp
+++ b/ImprovedCamera/source/skyrimse/SkyrimSE.cpp
@@ -22,7 +22,7 @@ namespace Patch {
 
 		m_FullName = pluginConfig->ModuleData().sFileName;
 		m_Name = m_FullName.substr(0, m_FullName.size() - 4);
-		m_WindowName = "Skyrim Special Edition";
+		m_WindowName = pluginConfig->ModuleData().sWindowName;
 
 		ExecutableInfo();
 		BuildInfo();


### PR DESCRIPTION
The window detection code does not use the one from the config file but instead a hard coded one.
This forces the game to wait 120sec. It also disables the menu.
This pull request fixes this issue
Tested on Enderal SE